### PR TITLE
Add `no_std` support to `fibril_core`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2021"
 authors = ["Jonathan Nadal <jon.nadal@gmail.com>"]
 description = "Core types for the Fibril library."
 
+[features]
+default = ["std"]
+
+# Provide impls for common standard library types like Vec<T> and HashMap<K, V>.
+# Requires a dependency on the Rust standard library.
+std = []
+
 [dependencies.serde]
 optional = true
 version = "1"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,8 @@
 //! This module specifies the core types for the Fibril library.
 
+// Support using Fibril core without the standard library.
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #![deny(unused_must_use)]
 #![warn(rust_2018_idioms, unreachable_pub)]
 


### PR DESCRIPTION
Not sure if the coroutine library dependency will ever support `no_std` environments, but there were minimal changes to make `fibril_core` be `no_std` compatible at least.